### PR TITLE
Missing Fio bank in mapping array

### DIFF
--- a/IBANtoBIC.php
+++ b/IBANtoBIC.php
@@ -71,6 +71,7 @@ class IBANtoBIC {
       "8180" => "SPSRSKBA",
       "8300" => "HSBCSKBA",
       "8320" => "JTBPSKBA",
+      "8330" => "FIOZSKBA",
       "8350" => "ABNASKBX",
       "8360" => "BREXSKBX",
       "9951" => "XBRASKB1",


### PR DESCRIPTION
Adding the missing BIC mapping to the FIO bank.