### PR TITLE
Fix deprecation notice in PHP 8.4

### DIFF
--- a/src/Exception/InvalidTypeException.php
+++ b/src/Exception/InvalidTypeException.php
@@ -11,7 +11,7 @@ final class InvalidTypeException extends QrPaymentException
      * @param mixed                $actual
      * @param int                  $code
      */
-    public function __construct($expected, $actual, $code = 0, Throwable $previous = null)
+    public function __construct($expected, $actual, $code = 0, ?Throwable $previous = null)
     {
         if (is_array($expected)) {
             $expected = implode("' or '", $expected);


### PR DESCRIPTION
See more: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated